### PR TITLE
Add rich text support to handle html tags contained by the text parameter

### DIFF
--- a/app/src/main/java/com/devs/readmoreoptiondemo/MyAdapter.java
+++ b/app/src/main/java/com/devs/readmoreoptiondemo/MyAdapter.java
@@ -16,8 +16,8 @@
 package com.devs.readmoreoptiondemo;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.support.v7.widget.RecyclerView;
+import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -62,8 +62,11 @@ public class MyAdapter extends RecyclerView.Adapter<MyAdapter.ViewHolder> {
 
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
-
-        readMoreOption.addReadMoreTo(holder.mTextView,context.getString(R.string.dummy_text));
+        if (position % 2 == 0) {
+            readMoreOption.addReadMoreTo(holder.mTextView, Html.fromHtml(context.getString(R.string.dummy_text)));
+        } else {
+            readMoreOption.addReadMoreTo(holder.mTextView, Html.fromHtml(context.getString(R.string.dummy_text)).toString());
+        }
     }
 
     // Return the size of your dataset (invoked by the layout manager)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,5 +15,5 @@
 
 <resources>
     <string name="app_name">ReadMoreOption</string>
-    <string name="dummy_text">Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.</string>
+    <string name="dummy_text"> <![CDATA[ <b>Lorem</b> <i>Ipsum</i> is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.]]></string>
 </resources>

--- a/readmoreoption/src/main/java/com/devs/readmoreoption/ReadMoreOption.java
+++ b/readmoreoption/src/main/java/com/devs/readmoreoption/ReadMoreOption.java
@@ -20,7 +20,9 @@ import android.content.Context;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Handler;
+import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextPaint;
 import android.text.method.LinkMovementMethod;
@@ -63,8 +65,7 @@ public class ReadMoreOption {
         this.expandAnimation = builder.expandAnimation;
     }
 
-    public void addReadMoreTo(final TextView textView, final String text){
-
+    public void addReadMoreTo(final TextView textView, final CharSequence text){
         if(textLengthType==TYPE_CHARACTER) {
             if (text.length() <= textLength) {
                 textView.setText(text);
@@ -93,12 +94,16 @@ public class ReadMoreOption {
 
                     ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams) textView.getLayoutParams();
 
-                    String subString = text.substring(textView.getLayout().getLineStart(0),
+                    String subString = text.toString().substring(textView.getLayout().getLineStart(0),
                             textView.getLayout().getLineEnd(textLength - 1));
                     textLengthNew = subString.length() - (moreLabel.length()+4+(lp.rightMargin/6));
                 }
 
-                SpannableString ss = new SpannableString(text.substring(0, textLengthNew) + "... "+ moreLabel);
+                SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(text.subSequence(0, textLengthNew))
+                        .append("...")
+                        .append(moreLabel);
+
+                SpannableString ss = SpannableString.valueOf(spannableStringBuilder);
                 ClickableSpan clickableSpan = new ClickableSpan() {
                     @Override
                     public void onClick(View view) {
@@ -123,13 +128,16 @@ public class ReadMoreOption {
                 textView.setMovementMethod(LinkMovementMethod.getInstance());
             }
         });
-
-
     }
 
-    private void addReadLess(final TextView textView, final String text ) {
+    private void addReadLess(final TextView textView, final CharSequence text) {
         textView.setMaxLines(Integer.MAX_VALUE);
-        SpannableString ss = new SpannableString(text + " "+ lessLabel);
+
+        SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(text)
+                .append(lessLabel);
+
+        SpannableString ss = SpannableString.valueOf(spannableStringBuilder);
+
         ClickableSpan clickableSpan = new ClickableSpan() {
             @Override
             public void onClick(View view) {


### PR DESCRIPTION
The currently released version does not support the displaying of the formatted text, for example if the text parameter contains html tags.
I have changed the type of the incoming `text` parameter  to `CharSequence`,  so currently it is compatible with the simple `String` (let say backward compatible) and it can support the formatted text as well. I made some small change in logic to support the new type.
I adapted the example application as well, so currently every second line in the list contains a formatted text.